### PR TITLE
Error Handling for refreshTokens in middleware

### DIFF
--- a/src/core/middleware.ts
+++ b/src/core/middleware.ts
@@ -50,7 +50,12 @@ export const authMiddleware: Middleware = async (ctx) => {
       // Token has expired. Check if refresh token is available.
       if (isRefreshable) {
         // Refresh token is available. Attempt refresh.
-        await ctx.$auth.refreshTokens()
+        try {
+          await ctx.$auth.refreshTokens()
+        } catch(error) {
+          // Reset when refresh was not successfull
+          ctx.$auth.reset()
+        }
       } else {
         // Refresh token is not available. Force reset.
         ctx.$auth.reset()


### PR DESCRIPTION
Adds error Handling for refreshTokens() call in middleware.

At the moment the app crashes with an unhandled Exception whenever thje refresh Request ist not successfull.